### PR TITLE
Fix keyword filter upon Firestore download

### DIFF
--- a/app/client/src/components/SettingPanels/Config.vue
+++ b/app/client/src/components/SettingPanels/Config.vue
@@ -605,7 +605,7 @@ export default {
       }
 
       this.data.keywords = this.data.keywords.filter(
-        v => v in this.keywords
+        v => Object.values(this.keywords).includes(v)
       )
       // this.data.listingTable.bannerImg.url
       // this.data.webpage.bannerImg.url


### PR DESCRIPTION
Signed-off-by: Andrew Chen <Andrew.Chen@windriver.com>

Filter by value instead of key.