### PR TITLE
Limit name lengths

### DIFF
--- a/app/client/notices.js
+++ b/app/client/notices.js
@@ -56,6 +56,21 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`
+  },
+  vuelidate: {
+    name: 'Vuelidate',
+    description: 'Simple, lightweight model-based validation for Vue.js',
+    url: 'https://github.com/vuelidate/vuelidate/blob/master/LICENSE',
+    notice: `
+MIT License
+
+Copyright (c) 2019 Damian Dulisz
+    
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`
   }
 }
 

--- a/app/client/quasar.conf.js
+++ b/app/client/quasar.conf.js
@@ -5,6 +5,7 @@ module.exports = function (ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     boot: [
+      'vuelidate'
     ],
 
     css: [

--- a/app/client/src/boot/vuelidate.js
+++ b/app/client/src/boot/vuelidate.js
@@ -1,0 +1,5 @@
+import Vuelidate from 'vuelidate'
+
+export default ({ Vue }) => {
+  Vue.use(Vuelidate)
+}

--- a/app/client/src/components/EditAndPreviewChallenge.vue
+++ b/app/client/src/components/EditAndPreviewChallenge.vue
@@ -411,12 +411,11 @@ Methods:
                                 <q-icon
                                   size=".8em" color="accent" name="edit"
                                 />
-
                                 <q-popup-edit
                                   buttons
                                   title="Edit Challenge Name"
                                   v-model="editedName"
-                                  :validate="() => !$v.editedName.$invalid"
+                                  :validate="validateName"
                                   @save="saveEditedName"
                                 >
                                   <q-input
@@ -2503,6 +2502,14 @@ export default {
         this.mainImage.cur = this.mainImage.prev
         this.mainImage.file = ''
       }
+    },
+    validateName (val) {
+      /**
+       * Validation for the challenge name: editedName.
+       * @param {String} val Dummy, unused variable for the QPopupEdit API
+       * @return {Promise<Boolean>}
+       */
+      return !this.$v.editedName.$invalid
     },
     onSubmit: async function () {
       /**

--- a/app/client/src/components/EditAndPreviewChallenge.vue
+++ b/app/client/src/components/EditAndPreviewChallenge.vue
@@ -417,7 +417,7 @@ Methods:
                                   title="Edit Challenge Name"
                                   v-model="editedName"
                                   :validate="() => !$v.editedName.$invalid"
-                                  @save="updated = true; curData.challenge = editedName"
+                                  @save="saveEditedName"
                                 >
                                   <q-input
                                     dense autofocus
@@ -2124,7 +2124,7 @@ export default {
       loading: false, // <Boolean>: flag for loading
       data: {}, // <Object>: static data of the component from db
       curData: {}, // <Object>: mutable copy of data
-      editedName: '', // <String>: Temporary name until submission
+      editedName: '', // <String>: Temporary name for submission
       pageTab: 'main', // <String>: tab value
       splitterModel: 15, // <Integer>: % of width the splitter will occupy
       priorityGague: { // <Object>: data for knob animation
@@ -2290,6 +2290,10 @@ export default {
     updateEditedName (inputValue) {
       this.editedName = inputValue
       this.$v.editedName.$touch()
+    },
+    saveEditedName () {
+      this.updated = true
+      this.curData.challenge = this.editedName
     },
     submitAddMembers: function () {
       /**

--- a/app/client/src/components/EditAndPreviewChallenge.vue
+++ b/app/client/src/components/EditAndPreviewChallenge.vue
@@ -416,12 +416,18 @@ Methods:
                                   buttons
                                   title="Edit Challenge Name"
                                   v-model="curData.challenge"
+                                  :validate="challengeNameValidation"
                                   @save="updated = true"
                                 >
                                   <q-input
                                     dense autofocus
                                     class="full-width"
-                                    v-model="curData.challenge"
+                                    :value="curData.challenge"
+                                    @input="updateEditedName($event.target.value)"
+                                    :rules="[
+                                      val => $v.curData.challenge.required || 'Field is required',
+                                      val => $v.curData.challenge.maxLength || 'Max length is 60 characters'
+                                    ]"
                                   />
                                 </q-popup-edit>
                               </div>
@@ -2034,6 +2040,8 @@ import 'firebase/firestore'
 import productionDb, { productionStorage } from '../firebase/init_production'
 import testingDb, { testingStorage } from '../firebase/init_testing'
 
+import { required, maxLength } from 'vuelidate/lib/validators'
+
 import UploadGUI from '../components/Upload'
 import ProjectTable from '../components/Tables/ProjectTable'
 import AddUser from '../components/SubmitUserAdminConsole'
@@ -2115,6 +2123,7 @@ export default {
       loading: false, // <Boolean>: flag for loading
       data: {}, // <Object>: static data of the component from db
       curData: {}, // <Object>: mutable copy of data
+      editedName: '', // <String>: Temporary name until submission
       pageTab: 'main', // <String>: tab value
       splitterModel: 15, // <Integer>: % of width the splitter will occupy
       priorityGague: { // <Object>: data for knob animation
@@ -2135,6 +2144,12 @@ export default {
       extraSponsorInfo: {
         img: {} // <Object>: dictionary of sponsor uid to avater image
       }
+    }
+  },
+  validations: {
+    editedName: {
+      required,
+      maxLength: maxLength(60)
     }
   },
   methods: {
@@ -2270,6 +2285,11 @@ export default {
 
       this.userEmailToObjMap[newUser.email] = newUser
       this.addMemberDialog.use.push(newUser)
+    },
+    updateEditedName (inputValue) {
+      debugger
+      this.editedName = inputValue
+      this.$v.editedName.$touch()
     },
     submitAddMembers: function () {
       /**
@@ -3111,17 +3131,17 @@ export default {
       }).onDismiss(() => {
       })
     },
-    projectNameValidation: function (val) {
+    challengeNameValidation: function () {
       /**
        * helper function to validate project name
-       * @param {String} val: string value to be validated
        * @return {Boolean}
        */
 
-      if (val === '') {
-        return false
+      if (this.$v.curData.challenge.maxLength && this.$v.curData.challenge.required) {
+        console.log(this.$v)
+        return true
       }
-      return true
+      return false
     },
     addCustomField: function () {
       /**

--- a/app/client/src/components/EditAndPreviewChallenge.vue
+++ b/app/client/src/components/EditAndPreviewChallenge.vue
@@ -415,18 +415,19 @@ Methods:
                                 <q-popup-edit
                                   buttons
                                   title="Edit Challenge Name"
-                                  v-model="curData.challenge"
-                                  :validate="challengeNameValidation"
-                                  @save="updated = true"
+                                  v-model="editedName"
+                                  :validate="() => !$v.editedName.$invalid"
+                                  @save="updated = true; curData.challenge = editedName"
                                 >
                                   <q-input
                                     dense autofocus
                                     class="full-width"
-                                    :value="curData.challenge"
-                                    @input="updateEditedName($event.target.value)"
+                                    :value="editedName"
+                                    @focus="editedName = curData.challenge"
+                                    @input="updateEditedName($event)"
                                     :rules="[
-                                      val => $v.curData.challenge.required || 'Field is required',
-                                      val => $v.curData.challenge.maxLength || 'Max length is 60 characters'
+                                      val => $v.editedName.required || 'Field is required',
+                                      val => $v.editedName.maxLength || 'Max length is 60 characters'
                                     ]"
                                   />
                                 </q-popup-edit>
@@ -2287,7 +2288,6 @@ export default {
       this.addMemberDialog.use.push(newUser)
     },
     updateEditedName (inputValue) {
-      debugger
       this.editedName = inputValue
       this.$v.editedName.$touch()
     },
@@ -3130,18 +3130,6 @@ export default {
       }).onCancel(() => {
       }).onDismiss(() => {
       })
-    },
-    challengeNameValidation: function () {
-      /**
-       * helper function to validate project name
-       * @return {Boolean}
-       */
-
-      if (this.$v.curData.challenge.maxLength && this.$v.curData.challenge.required) {
-        console.log(this.$v)
-        return true
-      }
-      return false
     },
     addCustomField: function () {
       /**

--- a/app/client/src/components/EditAndPreviewProject.vue
+++ b/app/client/src/components/EditAndPreviewProject.vue
@@ -304,13 +304,13 @@ Methods:
                                       :key="ulIndex"
                                     >
                                       <div
-                                        v-if="
+                                        v-if="(
                                           bodyContent.content.type ===
                                           'EVENT_LIST'
-                                        "
+                                        )"
                                         style="
-                                          display: inline; padding-left: 12px;
-                                        "
+                                            display: inline; padding-left: 12px;
+                                          "
                                       >
                                         {{ link.subject }}
                                         <hr>
@@ -366,12 +366,15 @@ Methods:
                             title="Edit the Project Name"
                             v-model="curData.project"
                             :validate="projectNameValidation"
-                            @save="updated = true"
+                            @save="updated = true; $v.curData.project.$touch()"
                           >
                             <q-input
                               dense autofocus filled hide-bottom-space
                               v-model="curData.project"
-                              :rules="[val => !!val || 'Field is required']"
+                              :rules="[
+                                val => $v.curData.project.required || 'Field is required',
+                                val => $v.curData.project.maxLength || 'Max length is 60 characters'
+                              ]"
                             />
                           </q-popup-edit>
 
@@ -1901,6 +1904,8 @@ import 'firebase/firestore'
 import productionDb, { productionStorage } from '../firebase/init_production'
 import testingDb, { testingStorage } from '../firebase/init_testing'
 
+import { required, maxLength } from 'vuelidate/lib/validators'
+
 import UploadGUI from '../components/Upload'
 import ProgressBar from '../components/ProgressBar'
 import AddUser from '../components/SubmitUserAdminConsole'
@@ -1992,6 +1997,14 @@ export default {
         // tags <Array<String>>: list of default values for the progress bar
         tags: ['Idea', 'PoC', 'Value'],
         half: true // <Boolean>: flag for half step
+      }
+    }
+  },
+  validations: {
+    curData: {
+      project: {
+        required,
+        maxLength: maxLength(60)
       }
     }
   },
@@ -2953,10 +2966,11 @@ export default {
        * @return {Boolean}
        */
 
-      if (val === '') {
-        return false
+      if (this.$v.curData.project.maxLength && this.$v.curData.project.required) {
+        console.log(this.$v)
+        return true
       }
-      return true
+      return false
     },
     addCustomField: function () {
       /**

--- a/app/client/src/components/EditAndPreviewProject.vue
+++ b/app/client/src/components/EditAndPreviewProject.vue
@@ -2959,10 +2959,9 @@ export default {
         // nothing goes here
       })
     },
-    projectNameValidation: function (val) {
+    projectNameValidation: function () {
       /**
        * helper function to validate the name of the project
-       * @param {String} val: the new title of the project
        * @return {Boolean}
        */
 

--- a/app/client/src/components/EditAndPreviewProject.vue
+++ b/app/client/src/components/EditAndPreviewProject.vue
@@ -364,7 +364,7 @@ Methods:
                             buttons
                             title="Edit Project Name"
                             v-model="editedName"
-                            :validate="() => !$v.editedName.$invalid"
+                            :validate="validateName"
                             @save="saveEditedName"
                           >
                             <q-input
@@ -2342,6 +2342,14 @@ export default {
         this.mainImage.file = ''
         // this.updated = false // removed for persistance
       }
+    },
+    validateName (val) {
+      /**
+       * Validation for the challenge name: editedName.
+       * @param {String} val Dummy, unused variable for the QPopupEdit API
+       * @return {Promise<Boolean>}
+       */
+      return !this.$v.editedName.$invalid
     },
     onSubmit: function () {
       /**

--- a/app/client/src/components/EditAndPreviewProject.vue
+++ b/app/client/src/components/EditAndPreviewProject.vue
@@ -360,20 +360,21 @@ Methods:
                             class="cursor-pointer"
                             name="edit" size=".8em" color="accent"
                           />
-
                           <q-popup-edit
                             buttons
-                            title="Edit the Project Name"
-                            v-model="curData.project"
-                            :validate="projectNameValidation"
-                            @save="updated = true; $v.curData.project.$touch()"
+                            title="Edit Project Name"
+                            v-model="editedName"
+                            :validate="() => !$v.editedName.$invalid"
+                            @save="saveEditedName"
                           >
                             <q-input
                               dense autofocus filled hide-bottom-space
-                              v-model="curData.project"
+                              :value="editedName"
+                              @focus="editedName = curData.project"
+                              @input="updateEditedName($event)"
                               :rules="[
-                                val => $v.curData.project.required || 'Field is required',
-                                val => $v.curData.project.maxLength || 'Max length is 60 characters'
+                                val => $v.editedName.required || 'Field is required',
+                                val => $v.editedName.maxLength || 'Max length is 60 characters'
                               ]"
                             />
                           </q-popup-edit>
@@ -1991,6 +1992,7 @@ export default {
       loading: false, // <Boolean>: flag for loading
       data: {}, // <Object>: static data of the component from db
       curData: {}, // <Object>: mutable copy of data
+      editedName: '', // <String>: Temporary name for submission
       pageTab: 'main', // <String>: tab value
       splitterModel: 15, // <Integer>: % of width the splitter will occupy
       progressBar: { // <Object>: default object of the progress bar
@@ -2001,11 +2003,9 @@ export default {
     }
   },
   validations: {
-    curData: {
-      project: {
-        required,
-        maxLength: maxLength(60)
-      }
+    editedName: {
+      required,
+      maxLength: maxLength(60)
     }
   },
   methods: {
@@ -2145,6 +2145,14 @@ export default {
       this.userEmailToObjMap[newUser.email] = newUser
       newUser.role = 'member'
       this.addMemberDialog.use.push(newUser)
+    },
+    updateEditedName (inputValue) {
+      this.editedName = inputValue
+      this.$v.editedName.$touch()
+    },
+    saveEditedName () {
+      this.updated = true
+      this.curData.project = this.editedName
     },
     submitAddMembers: function () {
       /**

--- a/app/client/src/components/EditUser.vue
+++ b/app/client/src/components/EditUser.vue
@@ -160,20 +160,14 @@ Methods:
                           Name:
                         </strong>
                         {{ curTocData.name }}
-                        <q-popup-edit
-                          buttons
-                          v-model="curTocData.name"
-                          :validate="popUpNameValidation"
-                          @hide="popUpReset"
-                          @save="reRender"
-                        >
-                          <q-input
-                            dense filled autofocus label="Name"
-                            :error="errorObj.error"
-                            :error-message="errorObj.message"
-                            v-model="curTocData.name"
-                          />
-                        </q-popup-edit>
+
+                        <limited-len-input-popup
+                          :initialValue="curTocData.name"
+                          :lenLimit="60"
+                          :label="name"
+                          @save="saveEditedName"
+                        />
+
                         <dir style="
                           font-style: italic;
                           color: gray;
@@ -385,6 +379,7 @@ import 'firebase/firestore'
 import productionDb, { productionStorage } from '../firebase/init_production'
 import testingDb, { testingStorage } from '../firebase/init_testing'
 
+import LimitedLenInputPopup from '../components/LimitedLenInputPopup'
 import ProjectTable from '../components/Tables/ProjectTable'
 
 export default {
@@ -394,7 +389,8 @@ export default {
   },
   components: {
     // uploadGUI
-    ProjectTable
+    ProjectTable,
+    LimitedLenInputPopup
   },
   async created () {
     try {
@@ -439,30 +435,6 @@ export default {
 
       this.errorObj.error = false
       this.errorObj.messsage = ''
-    },
-    popUpNameValidation: function (val) {
-      /**
-       * validation check for pop-up edit
-       * @param {String} val: value to be validated
-       * @return {void}
-       */
-
-      if (val === undefined) {
-        this.errorObj.error = false
-        this.errorObj.messsage = ''
-        return true
-      }
-
-      if (!val || val.length === 0) {
-        this.errorObj.error = true
-        this.errorObj.message = 'Cannot be empty!'
-        return false
-      }
-
-      // sucessful call
-      this.errorObj.error = false
-      this.errorObj.messsage = ''
-      return true
     },
     popUpEmailValidation: function (val) {
       /**
@@ -517,6 +489,10 @@ export default {
 
       this.updated = true
       this.$forceUpdate()
+    },
+    saveEditedName (editedName) {
+      this.curTocData.name = editedName
+      this.reRender()
     },
     deleteAdditionalInformation: function (entry) {
       /**

--- a/app/client/src/components/LimitedLenInputPopup.vue
+++ b/app/client/src/components/LimitedLenInputPopup.vue
@@ -1,5 +1,5 @@
 <!-- ##
-## Copyright (c) 2019 Wind River Systems, Inc.
+## Copyright (c) 2020 Wind River Systems, Inc.
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.

--- a/app/client/src/components/LimitedLenInputPopup.vue
+++ b/app/client/src/components/LimitedLenInputPopup.vue
@@ -1,0 +1,105 @@
+<!-- ##
+## Copyright (c) 2019 Wind River Systems, Inc.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at:
+##       http://www.apache.org/licenses/LICENSE-2.0
+## Unless required by applicable law or agreed to in writing, software  distributed
+## under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+## OR CONDITIONS OF ANY KIND, either express or implied.
+
+Name:     components/GetDataFromFirestore.vue
+Purpose:  To allow the user to export data from firestore and import data
+          into firestore
+Methods:
+  * Allows user to edit a string, usually a name. Defers two way binding until
+  * validated and submitted.
+
+## -->
+
+<template>
+  <q-popup-edit
+    buttons
+    :title="title"
+    v-model="editedName"
+    :validate="validateName"
+    @save="save"
+  >
+    <q-input
+      dense autofocus filled hide-bottom-space
+      :label="label"
+      :value="editedName"
+      @input="updateEditedName($event)"
+      :rules="[
+        val => $v.editedName.required || 'Field is required',
+        val => $v.editedName.maxLength || 'Max length is 60 characters'
+      ]"
+    />
+  </q-popup-edit>
+</template>
+
+<script>
+
+import { required, maxLength } from 'vuelidate/lib/validators'
+
+export default {
+  props: {
+    initialValue: {
+      type: String,
+      required: true
+    },
+    lenLimit: {
+      type: Number,
+      required: true
+    },
+    label: {
+      type: String,
+      default: ''
+    },
+    title: {
+      type: String,
+      default: ''
+    }
+  },
+  data () {
+    return {
+      editedName: this.initialValue // <String>: Temporary name for submission
+    }
+  },
+  validations () {
+    return {
+      editedName: {
+        required,
+        maxLength: maxLength(this.lenLimit)
+      }
+    }
+  },
+  methods: {
+    save () {
+      this.$emit('save', this.editedName)
+    },
+    updateEditedName (inputValue) {
+      /**
+       * Sets this.editName then notifies Vuelidate.
+       * @param {String} inputValue New value for this.editName.
+       * @return {Promise<Boolean>}
+      */
+      this.editedName = inputValue
+      this.$v.editedName.$touch()
+    },
+    validateName (val) {
+      /**
+       * Validation for the challenge name: editedName.
+       * @param {String} val Dummy, unused variable for the QPopupEdit API
+       * @return {Promise<Boolean>}
+       */
+      return !this.$v.editedName.$invalid
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/app/client/src/components/LimitedLenInputPopup.vue
+++ b/app/client/src/components/LimitedLenInputPopup.vue
@@ -28,12 +28,13 @@ Methods:
   >
     <q-input
       dense autofocus filled hide-bottom-space
+      clearable
       :label="label"
       :value="editedName"
       @input="updateEditedName($event)"
       :rules="[
         val => $v.editedName.required || 'Field is required',
-        val => $v.editedName.maxLength || 'Max length is 60 characters'
+        val => $v.editedName.maxLength || `Max length is ${lenLimit} characters`
       ]"
     />
   </q-popup-edit>

--- a/app/client/src/components/Upload.vue
+++ b/app/client/src/components/Upload.vue
@@ -61,18 +61,15 @@ Methods:
           >
             <div class="col">
               <strong>{{ k }}:</strong> {{ curData[k].key }}
-              <q-popup-edit
-                buttons
-                v-model="curData[k].key"
-              >
-                <q-input
-                  dense filled autofocus
-                  :label="k"
-                  v-model="curData[k].key"
-                />
-              </q-popup-edit>
-            </div>
 
+              <limited-len-input-popup
+                :initialValue="curData[k].key"
+                :lenLimit="30"
+                :label="k"
+                @save="curData[k].key = $event"
+              />
+
+            </div>
             <div class="col-1 center-div">
               <q-btn
                 flat round dense icon="close"
@@ -118,7 +115,12 @@ Methods:
 import productionDb, { productionStorage } from '../firebase/init_production'
 import testingDb, { testingStorage } from '../firebase/init_testing'
 
+import LimitedLenInputPopup from '../components/LimitedLenInputPopup.vue'
+
 export default {
+  components: {
+    LimitedLenInputPopup
+  },
   props: {
     uid: String,
     type: String

--- a/app/client/src/pages/SubmitChallenge.vue
+++ b/app/client/src/pages/SubmitChallenge.vue
@@ -59,7 +59,11 @@ Methods:
           placeholder="Please enter the name of the challenge..."
           label="Challenge Name"
           lazy-rules
-          :rules="[val => !!val || 'Field is required']"
+          :rules="[
+            val => $v.challengeName.required || 'Field is required',
+            val => $v.challengeName.maxLength || 'Max length is 60 characters'
+          ]"
+          @input="$v.challengeName.$touch()"
           @keydown.ctrl.shift.65="activateAdmin"
         >
           <template v-slot:prepend>
@@ -78,7 +82,8 @@ Methods:
           label="Description/Overview"
           type="textarea"
           lazy-rules
-          :rules="[val => !!val || 'Field is required']"
+          @input="$v.challengeDescription.$touch()"
+          :rules="[val => $v.challengeDescription.required || 'Field is required']"
         >
           <template v-slot:prepend>
             <q-icon name="far fa-comment-alt" />
@@ -145,7 +150,8 @@ Methods:
               v-model="sponsors[index].email"
               :ref="`memberEmail${index}`"
               :autofocus="index > 0"
-              :rules="[val => !!val || 'Field is required']"
+              :rules="[val => $v.sponsors.$each[index].email.required || 'Field is required']"
+              @input="$v.sponsors.$each[index].email.$touch()"
               @blur="emailDomainCheck(sponsors[index].email, index)"
             >
               <template v-slot:prepend>
@@ -160,7 +166,8 @@ Methods:
               placeholder="ie. John Doe" label="Contributor's Full Name"
               v-model="sponsors[index].name"
               :ref="`memberName${index}`"
-              :rules="[val => !!val || 'Field is required']"
+              :rules="[val => $v.sponsors.$each[index].name.required || 'Field is required']"
+              @input="$v.sponsors.$each[index].name.$touch()"
               @blur="capitalizeFirstChar(index)"
             >
               <template v-slot:prepend>
@@ -647,6 +654,8 @@ import testingDb from '../firebase/init_testing'
 
 import { layoutConfig } from '../../boundless.config'
 
+import { required, maxLength } from 'vuelidate/lib/validators'
+
 export default {
   async created () {
     try {
@@ -708,6 +717,25 @@ export default {
       addedContent: false,
       loading: false, // <Boolean>: flag for loading animation
       adminMode: false // <Boolean>: flag for activating admin mode
+    }
+  },
+  validations: {
+    challengeName: {
+      required,
+      maxLength: maxLength(60)
+    },
+    challengeDescription: {
+      required
+    },
+    sponsors: {
+      $each: {
+        name: {
+          required
+        },
+        email: {
+          required
+        }
+      }
     }
   },
   methods: {

--- a/app/client/src/pages/SubmitChallenge.vue
+++ b/app/client/src/pages/SubmitChallenge.vue
@@ -166,7 +166,10 @@ Methods:
               placeholder="ie. John Doe" label="Contributor's Full Name"
               v-model="sponsors[index].name"
               :ref="`memberName${index}`"
-              :rules="[val => $v.sponsors.$each[index].name.required || 'Field is required']"
+              :rules="[
+                val => $v.sponsors.$each[index].name.required || 'Field is required',
+                val => $v.sponsors.$each[index].name.maxLength || 'Max length is 60 characters'
+              ]"
               @input="$v.sponsors.$each[index].name.$touch()"
               @blur="capitalizeFirstChar(index)"
             >
@@ -730,7 +733,8 @@ export default {
     sponsors: {
       $each: {
         name: {
-          required
+          required,
+          maxLength: maxLength(60)
         },
         email: {
           required

--- a/app/client/src/pages/SubmitProject.vue
+++ b/app/client/src/pages/SubmitProject.vue
@@ -144,7 +144,10 @@ Methods:
               label="Contributor's Full Name"
               v-model="projectMembers[index].name"
               :ref="`memberName${index}`"
-              :rules="[val => $v.projectMembers.$each[index].name.required || 'Field is required']"
+              :rules="[
+                val => $v.projectMembers.$each[index].name.required || 'Field is required',
+                val => $v.projectMembers.$each[index].name.maxLength || 'Max length is 60 characters'
+              ]"
               @input="$v.projectMembers.$each[index].name.$touch()"
               @blur="capitalizeFirstChar(index)"
             >
@@ -678,7 +681,8 @@ export default {
     projectMembers: {
       $each: {
         name: {
-          required
+          required,
+          maxLength: maxLength(60)
         },
         email: {
           required

--- a/app/client/src/pages/SubmitProject.vue
+++ b/app/client/src/pages/SubmitProject.vue
@@ -53,7 +53,11 @@ Methods:
           placeholder="ie. Raspberry Pi BSP for VxWorks7"
           label="Project Name"
           v-model="projectName"
-          :rules="[val => !!val || 'Field is required']"
+          :rules="[
+            val => $v.projectName.required || 'Field is required',
+            val => $v.projectName.maxLength || 'Max length is 60 characters'
+          ]"
+          @input="$v.projectName.$touch()"
           @keydown.ctrl.shift.65="activateAdmin"
         >
           <template v-slot:prepend>
@@ -70,7 +74,8 @@ Methods:
           placeholder="Please give 2-5 sentences overview of the project. (Grows automatically.)"
           label="Description/Overview"
           type="textarea"
-          :rules="[val => !!val || 'Field is required']"
+          @input="$v.projectDescription.$touch()"
+          :rules="[val => $v.projectDescription.required || 'Field is required']"
         >
           <template v-slot:prepend>
             <q-icon name="far fa-comment-alt" />
@@ -122,7 +127,8 @@ Methods:
               label="Contributor's Email" type="email"
               v-model="projectMembers[index].email"
               :ref="`memberEmail${index}`"
-              :rules="[val => !!val || 'Field is required']"
+              :rules="[val => $v.projectMembers.$each[index].email.required || 'Field is required']"
+              @input="$v.projectMembers.$each[index].email.$touch()"
               @blur="emailDomainCheck(projectMembers[index].email, index)"
             >
               <template v-slot:prepend>
@@ -138,7 +144,8 @@ Methods:
               label="Contributor's Full Name"
               v-model="projectMembers[index].name"
               :ref="`memberName${index}`"
-              :rules="[val => !!val || 'Field is required']"
+              :rules="[val => $v.projectMembers.$each[index].name.required || 'Field is required']"
+              @input="$v.projectMembers.$each[index].name.$touch()"
               @blur="capitalizeFirstChar(index)"
             >
               <template v-slot:prepend>
@@ -614,6 +621,8 @@ Methods:
 import productionDb from '../firebase/init_production'
 import testingDb from '../firebase/init_testing'
 
+import { required, maxLength } from 'vuelidate/lib/validators'
+
 export default {
   async created () {
     try {
@@ -656,6 +665,25 @@ export default {
       addedContent: false,
       loading: false, // <Boolean>: flag for loading animation
       adminMode: false // <Boolean>: flag for activating admin mode
+    }
+  },
+  validations: {
+    projectName: {
+      required,
+      maxLength: maxLength(60)
+    },
+    projectDescription: {
+      required
+    },
+    projectMembers: {
+      $each: {
+        name: {
+          required
+        },
+        email: {
+          required
+        }
+      }
     }
   },
   methods: {

--- a/app/notices.yml
+++ b/app/notices.yml
@@ -68,3 +68,31 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.'
+
+vuelidate:
+  name: 'Vuelidate'
+  description: 'Simple, lightweight model-based validation for Vue.js'
+  url: 'https://github.com/vuelidate/vuelidate/blob/master/LICENSE'
+  notice: 'The MIT License (MIT)
+
+  MIT License
+
+  Copyright (c) 2019 Damian Dulisz
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.'


### PR DESCRIPTION
This limits the possible lengths for usernames, project names, challenge names, and file attachment alias names. 

I used [vuelidate](https://github.com/vuelidate/vuelidate) so that future validation could be easier to update. Most of the logic is done in the LimitedLenInputPopup component. Validation is done by giving visual feedback and preventing form submission if invalid.



![image](https://user-images.githubusercontent.com/10135459/86164796-334a7f80-bac7-11ea-9ae9-03b51d0c8c73.png)
