### PR TITLE
Adjusting project table, form response, and additional question pages

### DIFF
--- a/app/client/src/components/Forms/Project/ProjectMainForm.vue
+++ b/app/client/src/components/Forms/Project/ProjectMainForm.vue
@@ -40,7 +40,7 @@ Methods:
         <p class="q-mb-xl">
           Submit a problem or challenge (an itch)  you would like solve or explore (scratch).
         </p>
-        <q-separator />
+        <q-separator color="grey-5" />
         <!-- -------------------- Project Name -------------------- -->
         <q-input
           filled lazy-rules clearable
@@ -79,7 +79,7 @@ Methods:
           </template>
         </q-input>
 
-        <q-separator />
+        <q-separator color="grey-5" />
 
         <!--  -------------------- Keywords -------------------- -->
         <div class="row q-pa-sm" align="left">
@@ -93,7 +93,7 @@ Methods:
           />
         </div>
 
-        <q-separator />
+        <q-separator color="grey-5" />
 
         <!-- -------------------- Team Member -------------------- -->
         <div>
@@ -175,7 +175,7 @@ Methods:
 
         <!-- -------------------- Admin Mode -------------------- -->
         <div :hidden="!adminMode">
-          <q-separator />
+          <q-separator color="grey-5" />
           <!-- -------------------- Chips -------------------- -->
           <div>
             <div class="row" align="left">
@@ -214,7 +214,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Source Chip</strong>
-                    <q-separator class="col q-ml-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -237,7 +237,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Video Chip</strong>
-                    <q-separator class="col q-ml-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -315,7 +315,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Text Box</strong>
-                    <q-separator class="col q-ml-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -345,7 +345,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Unordered List</strong>
-                    <q-separator class="col q-ml-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -359,7 +359,7 @@ Methods:
 
                   <div class="row inline full-width q-pa-md">
                     <strong>List</strong>
-                    <q-separator class="col q-ml-sm q-mr-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm q-mr-sm" />
                     <div>
                       <q-btn
                         dense round
@@ -411,7 +411,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Ordered List</strong>
-                    <q-separator class="col q-ml-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -426,7 +426,7 @@ Methods:
 
                   <div class="row inline full-width q-pa-md">
                     <strong>List</strong>
-                    <q-separator class="col q-ml-sm q-mr-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm q-mr-sm" />
                     <div>
                       <q-btn
                         dense round
@@ -487,7 +487,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Event List</strong>
-                    <q-separator class="col q-ml-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -501,7 +501,7 @@ Methods:
 
                   <div class="row inline full-width q-pa-md">
                     <strong>List</strong>
-                    <q-separator class="col q-ml-sm q-mr-sm" />
+                    <q-separator color="grey-5" class="col q-ml-sm q-mr-sm" />
                     <div>
                       <q-btn
                         dense round

--- a/app/client/src/components/Forms/Project/ProjectMainForm.vue
+++ b/app/client/src/components/Forms/Project/ProjectMainForm.vue
@@ -40,7 +40,7 @@ Methods:
         <p class="q-mb-xl">
           Submit a problem or challenge (an itch)  you would like solve or explore (scratch).
         </p>
-        <q-separator class="newLine2" />
+        <q-separator />
         <!-- -------------------- Project Name -------------------- -->
         <q-input
           filled lazy-rules clearable
@@ -79,7 +79,7 @@ Methods:
           </template>
         </q-input>
 
-        <q-separator class="newLine2" />
+        <q-separator />
 
         <!--  -------------------- Keywords -------------------- -->
         <div class="row q-pa-sm" align="left">
@@ -93,7 +93,7 @@ Methods:
           />
         </div>
 
-        <q-separator class="newLine2" />
+        <q-separator />
 
         <!-- -------------------- Team Member -------------------- -->
         <div>
@@ -175,7 +175,7 @@ Methods:
 
         <!-- -------------------- Admin Mode -------------------- -->
         <div :hidden="!adminMode">
-          <q-separator class="newLine2" />
+          <q-separator />
           <!-- -------------------- Chips -------------------- -->
           <div>
             <div class="row" align="left">

--- a/app/client/src/components/Forms/Project/ProjectMainForm.vue
+++ b/app/client/src/components/Forms/Project/ProjectMainForm.vue
@@ -40,7 +40,7 @@ Methods:
         <p class="q-mb-xl">
           Submit a problem or challenge (an itch)  you would like solve or explore (scratch).
         </p>
-        <hr class="newLine2">
+        <q-separator class="newLine2" />
         <!-- -------------------- Project Name -------------------- -->
         <q-input
           filled lazy-rules clearable
@@ -79,7 +79,7 @@ Methods:
           </template>
         </q-input>
 
-        <hr class="newLine2">
+        <q-separator class="newLine2" />
 
         <!--  -------------------- Keywords -------------------- -->
         <div class="row q-pa-sm" align="left">
@@ -93,7 +93,7 @@ Methods:
           />
         </div>
 
-        <hr class="newLine2">
+        <q-separator class="newLine2" />
 
         <!-- -------------------- Team Member -------------------- -->
         <div>
@@ -175,7 +175,7 @@ Methods:
 
         <!-- -------------------- Admin Mode -------------------- -->
         <div :hidden="!adminMode">
-          <hr class="newLine2">
+          <q-separator class="newLine2" />
           <!-- -------------------- Chips -------------------- -->
           <div>
             <div class="row" align="left">
@@ -214,7 +214,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Source Chip</strong>
-                    <hr class="col q-ml-sm">
+                    <q-separator class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -237,7 +237,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Video Chip</strong>
-                    <hr class="col q-ml-sm">
+                    <q-separator class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -315,7 +315,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Text Box</strong>
-                    <hr class="col q-ml-sm">
+                    <q-separator class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -345,7 +345,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Unordered List</strong>
-                    <hr class="col q-ml-sm">
+                    <q-separator class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -359,7 +359,7 @@ Methods:
 
                   <div class="row inline full-width q-pa-md">
                     <strong>List</strong>
-                    <hr class="col q-ml-sm q-mr-sm">
+                    <q-separator class="col q-ml-sm q-mr-sm" />
                     <div>
                       <q-btn
                         dense round
@@ -411,7 +411,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Ordered List</strong>
-                    <hr class="col q-ml-sm">
+                    <q-separator class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -426,7 +426,7 @@ Methods:
 
                   <div class="row inline full-width q-pa-md">
                     <strong>List</strong>
-                    <hr class="col q-ml-sm q-mr-sm">
+                    <q-separator class="col q-ml-sm q-mr-sm" />
                     <div>
                       <q-btn
                         dense round
@@ -487,7 +487,7 @@ Methods:
                 <q-card class="q-pa-md">
                   <div class="row" align="left">
                     <strong>Event List</strong>
-                    <hr class="col q-ml-sm">
+                    <q-separator class="col q-ml-sm" />
                   </div>
 
                   <q-input
@@ -501,7 +501,7 @@ Methods:
 
                   <div class="row inline full-width q-pa-md">
                     <strong>List</strong>
-                    <hr class="col q-ml-sm q-mr-sm">
+                    <q-separator class="col q-ml-sm q-mr-sm" />
                     <div>
                       <q-btn
                         dense round

--- a/app/client/src/components/Forms/Project/ProjectReviewForm.vue
+++ b/app/client/src/components/Forms/Project/ProjectReviewForm.vue
@@ -54,7 +54,7 @@ Methods:
         </template>
       </q-input>
 
-      <q-separator />
+      <q-separator color="grey-5" />
 
       <div class="row q-pa-sm" align="left">
         <p class="col-4 header">Keywords:</p>
@@ -67,7 +67,7 @@ Methods:
         />
       </div>
 
-      <q-separator />
+      <q-separator color="grey-5" />
 
       <div>
         <div class="row">
@@ -122,7 +122,7 @@ Methods:
             v-for="question in customFormResponse"
             :key="question.label"
           >
-            <q-separator />
+            <q-separator color="grey-5" />
 
             <q-input
               borderless readonly stack-label
@@ -133,7 +133,7 @@ Methods:
             />
           </div>
 
-          <q-separator />
+          <q-separator color="grey-5" />
 
         </div>
         <div v-else>

--- a/app/client/src/components/Forms/Project/ProjectReviewForm.vue
+++ b/app/client/src/components/Forms/Project/ProjectReviewForm.vue
@@ -33,7 +33,7 @@ Methods:
       <h6>Main info</h6>
 
       <q-input
-        filled readonly stack-label
+        borderless readonly stack-label
         label="Project Name"
         :value="projectName"
       >
@@ -43,7 +43,7 @@ Methods:
       </q-input>
 
       <q-input
-        filled autogrow readonly stack-label
+        borderless autogrow readonly stack-label
         class="q-my-sm"
         label="Description/Overview"
         type="textarea"
@@ -79,11 +79,11 @@ Methods:
         <div
           v-for="(member, index) in projectMembers"
           :key="index"
-          class="row q-mb-xs"
+          class="row q-col-gutter-y-sm items-center"
         >
           <q-input
-            filled readonly stack-label
-            class="col q-pr-xs"
+            borderless readonly stack-label
+            class="col-5 q-pr-xs"
             label="Contributor's Email" type="email"
             :value="projectMembers[index].email"
           >
@@ -93,8 +93,8 @@ Methods:
           </q-input>
 
           <q-input
-            filled readonly stack-label
-            class="col q-pl-xs"
+            borderless readonly stack-label
+            class="col-3 q-pl-xs"
             label="Contributor's Full Name"
             :value="projectMembers[index].name"
           >
@@ -103,17 +103,10 @@ Methods:
             </template>
           </q-input>
 
-          <div class="col-1">
-            <q-card flat align="center">
+          <div class="col"
+              v-if="projectMembers[index].role == 'lead'"
+          >
               Lead
-              <q-toggle
-                disable
-                color="secondary"
-                true-value="lead"
-                false-value="member"
-                :value="projectMembers[index].role"
-              />
-            </q-card>
           </div>
         </div>
       </div>
@@ -130,7 +123,7 @@ Methods:
             :key="question.label"
           >
             <q-input
-              filled readonly stack-label
+              borderless readonly stack-label
               class="q-mt-sm"
               :label="question.label"
               :type="question.type.value"

--- a/app/client/src/components/Forms/Project/ProjectReviewForm.vue
+++ b/app/client/src/components/Forms/Project/ProjectReviewForm.vue
@@ -54,7 +54,7 @@ Methods:
         </template>
       </q-input>
 
-      <hr class="newLine2">
+      <q-separator />
 
       <div class="row q-pa-sm" align="left">
         <p class="col-4 header">Keywords:</p>
@@ -67,7 +67,7 @@ Methods:
         />
       </div>
 
-      <hr class="newLine2">
+      <q-separator />
 
       <div>
         <div class="row">
@@ -122,6 +122,8 @@ Methods:
             v-for="question in customFormResponse"
             :key="question.label"
           >
+            <q-separator />
+
             <q-input
               borderless readonly stack-label
               class="q-mt-sm"
@@ -130,6 +132,9 @@ Methods:
               :value="question.response"
             />
           </div>
+
+          <q-separator />
+
         </div>
         <div v-else>
           <p>(No custom form questions for this project.)</p>

--- a/app/client/src/components/Forms/Project/ProjectReviewForm.vue
+++ b/app/client/src/components/Forms/Project/ProjectReviewForm.vue
@@ -38,7 +38,7 @@ Methods:
         :value="projectName"
       >
         <template v-slot:prepend>
-          <q-icon name="fas fa-project-diagram" />
+          <q-icon class="q-mr-sm" name="fas fa-project-diagram" />
         </template>
       </q-input>
 

--- a/app/client/src/pages/DisplayProjects.vue
+++ b/app/client/src/pages/DisplayProjects.vue
@@ -178,7 +178,6 @@ Methods:
             <q-td
               key="new"
               :props="props"
-              style="width: 95px;"
             >
               <q-icon
                 v-if="todayDate <= (props.row.created ? props.row.created.substring(0, 10) : props.row.timestamp.substring(0, 10))"
@@ -194,7 +193,7 @@ Methods:
             <q-td
               key="project"
               :props="props">
-              {{ props.row.project }}
+              <p>{{ props.row.project }}</p>
             </q-td>
             <!-- Description column -->
             <q-td
@@ -203,21 +202,19 @@ Methods:
               style="max-width: 300px; min-width: 220px;"
             >
               <div class="row">
-                <div
+                <p
                   class="col"
-                  ref="descriptionDiv"
                   align="left"
-                  style="overflow: hidden;"
                 >
                   {{ props.row.description }}
-                </div>
+                </p>
 
                 <div
                   :hidden="!(props.row.description.length > 60)"
-                  class="col-2"
+                  class="col-1"
                 >
                   <div
-                    class="text-blue cursor-pointer q-mx-sm"
+                    class="text-blue cursor-pointer"
                     @click="popDialog(props.row.description)"
                   >
                     [more]
@@ -364,7 +361,9 @@ export default {
           field: row => row.created || row.timestamp,
           align: 'center',
           sortable: true,
-          sort: (a, b) => (b > a) ? 1 : ((a > b) ? -1 : 0)
+          sort: (a, b) => (b > a) ? 1 : ((a > b) ? -1 : 0),
+          headerClasses: 'project-new-col',
+          classes: 'project-new-col'
         },
         {
           name: 'project',
@@ -381,7 +380,9 @@ export default {
           name: 'description',
           align: 'center',
           label: 'Description',
-          field: row => row.description
+          field: row => row.description,
+          headerClasses: 'project-description-col',
+          classes: 'project-description-col'
         },
         {
           name: 'progress',
@@ -702,16 +703,29 @@ export default {
 
 <style lang="stylus" scoped>
 
+.project-new-col
+  width 5%
+
 .project-name-col
-  width 22%
   font-weight bold
-  text-align left
+  text-align left // max width of max length name
+
+// Hide name overflow
+.project-description-col p,
+.project-name-col p
+  white-space nowrap
+  overflow hidden
+  text-overflow: ellipsis
+  width 300px
+
+.project-description-col
+  width 40%
 
 .progress-bar-col
-  width 12%
+  width 26%
 
 .lead-members-col
-  width 26%
+  width 20%
   overflow-wrap break-word
   overflow normal
 


### PR DESCRIPTION
Adjust the Project table

* Limited long names by cutting them off and appending "..." instead of displaying the whole thing.
* Made sure that columns widths are consistent no matter what's displayed.
* Enlarged the description and project progress columns by shrinking project names and project leads columns.

Reformat Form Reponses page,
Reformat Addition Questions page

* Made it more clear that data displayed here could not be edited, that it was just a review page.
* Added separators between custom form responses to make division more clear if there were empty responses.

